### PR TITLE
Patches over read when use raw binary streaming write.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileGenerator.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/smile/SmileGenerator.java
@@ -1943,6 +1943,9 @@ public class SmileGenerator
                 _flushBuffer();
                 room = _outputEnd - _outputTail;
             }
+            if (room > bytesLeft) {
+            	room = bytesLeft;
+            }
             int count = in.read(_outputBuffer, _outputTail, room);
             if (count < 0) {
                 break;

--- a/src/test/java/com/fasterxml/jackson/dataformat/smile/TestSmileGeneratorBinary.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/smile/TestSmileGeneratorBinary.java
@@ -5,6 +5,7 @@ import java.io.*;
 import org.junit.Assert;
 
 import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.dataformat.smile.SmileGenerator.Feature;
 
 public class TestSmileGeneratorBinary extends SmileTestBase
 {
@@ -58,6 +59,37 @@ public class TestSmileGeneratorBinary extends SmileTestBase
             verifyException(e, "must pass actual length");
         }
         jg.close();
+    }
+    
+    public void testStreamingBinaryPartly() throws Exception {
+    	_testStreamingBinaryPartly(true);
+    	_testStreamingBinaryPartly(false);
+    }
+    
+    private void _testStreamingBinaryPartly(boolean rawBinary) throws Exception
+    {
+    	final SmileFactory f = new SmileFactory();
+    	f.configure(Feature.ENCODE_BINARY_AS_7BIT, rawBinary);
+    	
+    	final byte[] INPUT = TEXT4.getBytes("UTF-8");
+    	ByteArrayInputStream in = new ByteArrayInputStream(INPUT);
+    	
+    	ByteArrayOutputStream out = new ByteArrayOutputStream();
+    	JsonGenerator jg = f.createGenerator(out);
+    	jg.writeStartArray();
+    	jg.writeBinary(in, 1);
+    	jg.writeEndArray();
+    	jg.close();
+    	in.close();
+    	
+        JsonParser jp = f.createParser(out.toByteArray());
+        assertToken(JsonToken.START_ARRAY, jp.nextToken());
+        assertToken(JsonToken.VALUE_EMBEDDED_OBJECT, jp.nextToken());
+        byte[] b = jp.getBinaryValue();
+        assertToken(JsonToken.END_ARRAY, jp.nextToken());
+        jp.close();
+    	
+    	assertEquals(1, b.length);
     }
     
     /*


### PR DESCRIPTION
When specified streaming write with length on raw binary, try to fill whole buffer room makes over read stream and results broken format. (binary length != real length)

Length check before fill to buffer to fix.
